### PR TITLE
Add unpackaged files (OLD)

### DIFF
--- a/spdx/document.py
+++ b/spdx/document.py
@@ -316,6 +316,7 @@ class Document(object):
         self.packages = []
         if package is not None:
             self.packages.append(package)
+        self.unpackaged_files = []
         self.extracted_licenses = []
         self.reviews = []
         self.annotations = []
@@ -330,6 +331,9 @@ class Document(object):
 
     def add_relationships(self, relationship):
         self.relationships.append(relationship)
+
+    def add_file(self, value):
+        self.unpackaged_files.append(value)
 
     def add_extr_lic(self, lic):
         self.extracted_licenses.append(lic)
@@ -370,10 +374,16 @@ class Document(object):
 
     @property
     def files(self):
+        warnings.warn('document.package and document.files are deprecated; '
+                      'use document.packages instead',
+                      DeprecationWarning)
         return self.package.files
 
     @files.setter
     def files(self, value):
+        warnings.warn('document.package and document.files are deprecated; '
+                      'use document.packages instead',
+                      DeprecationWarning)
         self.package.files = value
 
     @property
@@ -400,6 +410,7 @@ class Document(object):
         self.validate_creation_info(messages)
         self.validate_packages(messages)
         self.validate_extracted_licenses(messages)
+        self.validate_unpackaged_files(messages)
         self.validate_reviews(messages)
         self.validate_snippet(messages)
         self.validate_annotations(messages)
@@ -487,3 +498,6 @@ class Document(object):
                     "Document extracted licenses must be of type "
                     "spdx.document.ExtractedLicense and not " + type(lic)
                 )
+    def validate_unpackaged_files(self, messages):
+        for value in self.unpackaged_files:
+            messages = value.validate(messages)

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -499,6 +499,7 @@ class Document(object):
                     "Document extracted licenses must be of type "
                     "spdx.document.ExtractedLicense and not " + type(lic)
                 )
+
     def validate_unpackaged_files(self, messages):
         for spdx_file in self.unpackaged_files:
             messages = spdx_file.validate(messages)

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -279,6 +279,7 @@ class Document(object):
     - documentNamespace: SPDX document specific namespace. Mandatory, one. Type: str
     - creation_info: SPDX file creation info. Mandatory, one. Type: CreationInfo
     - package: Package described by this document. Mandatory, one. Type: Package
+    - unpackaged_files: Files not part of any package. Optional zero or more. Type: File.
     - extracted_licenses: List of licenses extracted that are not part of the
       SPDX license list. Optional, many. Type: ExtractedLicense.
     - reviews: SPDX document review information, Optional zero or more.
@@ -499,5 +500,5 @@ class Document(object):
                     "spdx.document.ExtractedLicense and not " + type(lic)
                 )
     def validate_unpackaged_files(self, messages):
-        for value in self.unpackaged_files:
-            messages = value.validate(messages)
+        for spdx_file in self.unpackaged_files:
+            messages = spdx_file.validate(messages)

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -399,9 +399,10 @@ class PackageParser(LicenseParser):
             self.more_than_one_error("package comment")
 
     def p_pkg_has_file(self, p_term, predicate):
-        for _, _, has_file in self.graph.triples((p_term, predicate, None)):
+        for _, _, has_file_object in self.graph.triples((p_term, predicate, None)):
             for index, spdx_file in enumerate(self.doc.unpackaged_files):
-                if str(has_file) == spdx_file.spdx_id:
+                object_spdx_id = str(has_file_object)
+                if spdx_file.spdx_id == object_spdx_id:
                     self.doc.packages[-1].files.append(spdx_file)
                     del self.doc.unpackaged_files[index]
 

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -366,6 +366,7 @@ class PackageParser(LicenseParser):
         self.p_pkg_summary(p_term, self.spdx_namespace["summary"])
         self.p_pkg_descr(p_term, self.spdx_namespace["description"])
         self.p_pkg_comment(p_term, self.spdx_namespace["comment"])
+        self.p_pkg_has_file(p_term, self.spdx_namespace["hasFile"])
 
     def p_pkg_cr_text(self, p_term, predicate):
         try:
@@ -396,6 +397,13 @@ class PackageParser(LicenseParser):
                 self.builder.set_pkg_comment(self.doc, str(comment))
         except CardinalityError:
             self.more_than_one_error("package comment")
+
+    def p_pkg_has_file(self, p_term, predicate):
+        for _, _, has_file in self.graph.triples((p_term, predicate, None)):
+            for index, spdx_file in enumerate(self.doc.unpackaged_files):
+                if str(has_file) == spdx_file.spdx_id:
+                    self.doc.packages[-1].files.append(spdx_file)
+                    del self.doc.unpackaged_files[index]
 
     def p_pkg_attribution_text(self, p_term, predicate):
         try:
@@ -1319,7 +1327,8 @@ class Parser(
             (None, self.spdx_namespace["referencesFile"], None)
         ):
             if not str(s) == self.doc.spdx_id:
-                self.parse_file(o)  # Package child ref file
+                # self.parse_file(o)  # TODO: Package child ref file?
+                raise NotImplementedError(f"Processing {s} referencesFile")
 
         for s, _p, o in self.graph.triples(
             (None, RDF.type, self.spdx_namespace["Snippet"])

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -17,6 +17,7 @@ from rdflib import Graph
 from rdflib import Namespace
 from rdflib import RDF
 from rdflib import RDFS
+from rdflib.term import URIRef
 
 from spdx import document
 from spdx import utils
@@ -1300,6 +1301,11 @@ class Parser(
             self.handle_extracted_license(s)
 
         for s, _p, o in self.graph.triples(
+            (URIRef(self.doc.spdx_id), self.spdx_namespace["referencesFile"], None)
+        ):
+            self.parse_file(o)  # Document-level ref file (unpackaged)
+
+        for s, _p, o in self.graph.triples(
             (None, RDF.type, self.spdx_namespace["Package"])
         ):
             self.parse_package(s)
@@ -1312,7 +1318,8 @@ class Parser(
         for s, _p, o in self.graph.triples(
             (None, self.spdx_namespace["referencesFile"], None)
         ):
-            self.parse_file(o)
+            if not str(s) == self.doc.spdx_id:
+                self.parse_file(o)  # Package child ref file
 
         for s, _p, o in self.graph.triples(
             (None, RDF.type, self.spdx_namespace["Snippet"])

--- a/spdx/parsers/rdfbuilders.py
+++ b/spdx/parsers/rdfbuilders.py
@@ -386,9 +386,12 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Set the file check sum, if not already set.
         chk_sum - A string
         Raise CardinalityError if already defined.
-        Raise OrderError if no package previously defined.
+        Raise OrderError if no package/unpackaged file previously defined.
         """
-        if self.has_package(doc) and self.has_file(doc):
+        if (
+            (self.has_package(doc) and self.has_file(doc))
+            or (self.has_unpackaged_file(doc) and not self.package_set)
+        ):
             if not self.file_chksum_set:
                 self.file_chksum_set = True
                 self.file(doc).chk_sum = checksum.Algorithm("SHA1", chk_sum)
@@ -403,7 +406,10 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or file defined.
         Raise CardinalityError if more than one per file.
         """
-        if self.has_package(doc) and self.has_file(doc):
+        if (
+            (self.has_package(doc) and self.has_file(doc))
+            or (self.has_unpackaged_file(doc) and not self.package_set)
+        ):
             if not self.file_license_comment_set:
                 self.file_license_comment_set = True
                 self.file(doc).license_comment = text
@@ -417,7 +423,10 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         """
         Set the file's attribution text.
         """
-        if self.has_package(doc) and self.has_file(doc):
+        if (
+            (self.has_package(doc) and self.has_file(doc))
+            or (self.has_unpackaged_file(doc) and not self.package_set)
+        ):
             self.assert_package_exists()
             self.file(doc).attribution_text = text
             return True
@@ -427,7 +436,10 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or file defined.
         Raise CardinalityError if more than one.
         """
-        if self.has_package(doc) and self.has_file(doc):
+        if (
+            (self.has_package(doc) and self.has_file(doc))
+            or (self.has_unpackaged_file(doc) and not self.package_set)
+        ):
             if not self.file_copytext_set:
                 self.file_copytext_set = True
                 self.file(doc).copyright = text
@@ -442,7 +454,10 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or no file defined.
         Raise CardinalityError if more than one comment set.
         """
-        if self.has_package(doc) and self.has_file(doc):
+        if (
+            (self.has_package(doc) and self.has_file(doc))
+            or (self.has_unpackaged_file(doc) and not self.package_set)
+        ):
             if not self.file_comment_set:
                 self.file_comment_set = True
                 self.file(doc).comment = text
@@ -457,7 +472,10 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or file defined.
         Raise CardinalityError if more than one.
         """
-        if self.has_package(doc) and self.has_file(doc):
+        if (
+            (self.has_package(doc) and self.has_file(doc))
+            or (self.has_unpackaged_file(doc) and not self.package_set)
+        ):
             if not self.file_notice_set:
                 self.file_notice_set = True
                 self.file(doc).notice = tagvaluebuilders.str_from_text(text)

--- a/spdx/parsers/rdfbuilders.py
+++ b/spdx/parsers/rdfbuilders.py
@@ -388,10 +388,7 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise CardinalityError if already defined.
         Raise OrderError if no package/unpackaged file previously defined.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_chksum_set:
                 self.file_chksum_set = True
                 self.file(doc).chk_sum = checksum.Algorithm("SHA1", chk_sum)
@@ -406,10 +403,7 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or file defined.
         Raise CardinalityError if more than one per file.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_license_comment_set:
                 self.file_license_comment_set = True
                 self.file(doc).license_comment = text
@@ -423,10 +417,7 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         """
         Set the file's attribution text.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             self.assert_package_exists()
             self.file(doc).attribution_text = text
             return True
@@ -436,10 +427,7 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or file defined.
         Raise CardinalityError if more than one.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_copytext_set:
                 self.file_copytext_set = True
                 self.file(doc).copyright = text
@@ -454,10 +442,7 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or no file defined.
         Raise CardinalityError if more than one comment set.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_comment_set:
                 self.file_comment_set = True
                 self.file(doc).comment = text
@@ -472,10 +457,7 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Raise OrderError if no package or file defined.
         Raise CardinalityError if more than one.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_notice_set:
                 self.file_notice_set = True
                 self.file(doc).notice = tagvaluebuilders.str_from_text(text)

--- a/spdx/parsers/rdfbuilders.py
+++ b/spdx/parsers/rdfbuilders.py
@@ -386,7 +386,7 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         Set the file check sum, if not already set.
         chk_sum - A string
         Raise CardinalityError if already defined.
-        Raise OrderError if no package/unpackaged file previously defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         """
         if (self._build_file_valid(doc)):
             if not self.file_chksum_set:

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -564,7 +564,8 @@ class Parser(object):
         value = p[2]
         if not self.builder.doc_spdx_id_set:
             self.builder.set_doc_spdx_id(self.document, value)
-        elif not self.builder.package_spdx_id_set:
+        elif (not self.builder.package_spdx_id_set
+                and self.builder.package_set):
             self.builder.set_pkg_spdx_id(self.document, value)
         else:
             self.builder.set_file_spdx_id(self.document, value)

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -162,22 +162,6 @@ class DocBuilder(object):
         else:
             raise CardinalityError("Document::Comment")
 
-    def set_doc_pkgs_started(self, doc):
-        """
-        Indicate Package has been set.
-        Raise value error if malformed value.
-        Raise CardinalityError if already defined.
-        """
-        if not self.doc_pkgs_started_set:
-            if len(doc.packages) == "SPDXRef-DOCUMENT":
-                doc.spdx_id = doc_spdx_id_line
-                self.doc_pkgs_started_set = True
-                return True
-            else:
-                raise SPDXValueError("Document::SPDXID")
-        else:
-            raise CardinalityError("Document::SPDXID")
-
     def reset_document(self):
         """
         Reset the state to allow building new documents
@@ -189,7 +173,6 @@ class DocBuilder(object):
         self.doc_data_lics_set = False
         self.doc_name_set = False
         self.doc_spdx_id_set = False
-        self.doc_pkgs_started_set = False
 
 
 class ExternalDocumentRefBuilder(object):

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -1059,7 +1059,7 @@ class FileBuilder(object):
     def set_file_spdx_id(self, doc, spdx_id):
         """
         Set the file SPDX Identifier.
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise SPDXValueError if malformed value.
         Raise CardinalityError if more than one spdx_id set.
         """
@@ -1078,7 +1078,7 @@ class FileBuilder(object):
 
     def set_file_comment(self, doc, text):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise CardinalityError if more than one comment set.
         Raise SPDXValueError if text is not free form text.
         """
@@ -1109,7 +1109,7 @@ class FileBuilder(object):
 
     def set_file_type(self, doc, type_value):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise CardinalityError if more than one type set.
         Raise SPDXValueError if type is unknown.
         """
@@ -1134,7 +1134,7 @@ class FileBuilder(object):
 
     def set_file_chksum(self, doc, chksum):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise CardinalityError if more than one chksum set.
         """
         if (self._build_file_valid(doc)):
@@ -1149,7 +1149,7 @@ class FileBuilder(object):
 
     def set_concluded_license(self, doc, lic):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise CardinalityError if already set.
         Raise SPDXValueError if malformed.
         """
@@ -1168,7 +1168,7 @@ class FileBuilder(object):
 
     def set_file_license_in_file(self, doc, lic):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise SPDXValueError if malformed value.
         """
         if (self._build_file_valid(doc)):
@@ -1182,7 +1182,7 @@ class FileBuilder(object):
 
     def set_file_license_comment(self, doc, text):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise SPDXValueError if text is not free form text.
         Raise CardinalityError if more than one per file.
         """
@@ -1200,7 +1200,7 @@ class FileBuilder(object):
 
     def set_file_copyright(self, doc, text):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise SPDXValueError if not free form text or NONE or NO_ASSERT.
         Raise CardinalityError if more than one.
         """
@@ -1222,7 +1222,7 @@ class FileBuilder(object):
 
     def set_file_notice(self, doc, text):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         Raise SPDXValueError if not free form text.
         Raise CardinalityError if more than one.
         """
@@ -1240,7 +1240,7 @@ class FileBuilder(object):
 
     def add_file_contribution(self, doc, value):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         """
         if (self._build_file_valid(doc)):
             self.file(doc).add_contrib(value)
@@ -1249,7 +1249,7 @@ class FileBuilder(object):
 
     def add_file_dep(self, doc, value):
         """
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         """
         if (self._build_file_valid(doc)):
             self.file(doc).add_depend(value)
@@ -1259,7 +1259,7 @@ class FileBuilder(object):
     def set_file_atrificat_of_project(self, doc, symbol, value):
         """
         Set a file name, uri or home artificat.
-        Raise OrderError if no package/unpackaged file is defined.
+        Raise OrderError if no package, package file, or unpackaged file is defined.
         """
         if (self._build_file_valid(doc)):
             self.file(doc).add_artifact(symbol, value)

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -1031,6 +1031,16 @@ class FileBuilder(object):
         # FIXME: this state does not make sense
         self.reset_file_stat()
 
+    def _build_file_valid(self, doc):
+        """
+        Return true if building a File for referenced document is valid.
+        """
+        if self.has_package(doc) and self.has_file(doc):
+            return True
+        if not self.package_set and self.has_unpackaged_file(doc):
+            return True
+        return False
+
     def set_file_name(self, doc, name):
         """
         Set the file name.
@@ -1053,10 +1063,7 @@ class FileBuilder(object):
         Raise SPDXValueError if malformed value.
         Raise CardinalityError if more than one spdx_id set.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_spdx_id_set:
                 self.file_spdx_id_set = True
                 if validations.validate_file_spdx_id(spdx_id):
@@ -1075,10 +1082,7 @@ class FileBuilder(object):
         Raise CardinalityError if more than one comment set.
         Raise SPDXValueError if text is not free form text.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_comment_set:
                 self.file_comment_set = True
                 if validations.validate_file_comment(text):
@@ -1096,10 +1100,7 @@ class FileBuilder(object):
         Set the file's attribution text .
         Raise SPDXValueError if text is not free form text.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if validations.validate_file_attribution_text(text):
                 self.file(doc).comment = str_from_text(text)
                 return True
@@ -1118,10 +1119,7 @@ class FileBuilder(object):
             "ARCHIVE": file.FileType.ARCHIVE,
             "OTHER": file.FileType.OTHER,
         }
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_type_set:
                 self.file_type_set = True
                 if type_value in type_dict.keys():
@@ -1139,10 +1137,7 @@ class FileBuilder(object):
         Raise OrderError if no package/unpackaged file is defined.
         Raise CardinalityError if more than one chksum set.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_chksum_set:
                 self.file_chksum_set = True
                 self.file(doc).chk_sum = checksum_from_sha1(chksum)
@@ -1158,10 +1153,7 @@ class FileBuilder(object):
         Raise CardinalityError if already set.
         Raise SPDXValueError if malformed.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_conc_lics_set:
                 self.file_conc_lics_set = True
                 if validations.validate_lics_conc(lic):
@@ -1179,10 +1171,7 @@ class FileBuilder(object):
         Raise OrderError if no package/unpackaged file is defined.
         Raise SPDXValueError if malformed value.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if validations.validate_file_lics_in_file(lic):
                 self.file(doc).add_lics(lic)
                 return True
@@ -1197,10 +1186,7 @@ class FileBuilder(object):
         Raise SPDXValueError if text is not free form text.
         Raise CardinalityError if more than one per file.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_license_comment_set:
                 self.file_license_comment_set = True
                 if validations.validate_file_lics_comment(text):
@@ -1218,10 +1204,7 @@ class FileBuilder(object):
         Raise SPDXValueError if not free form text or NONE or NO_ASSERT.
         Raise CardinalityError if more than one.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_copytext_set:
                 self.file_copytext_set = True
                 if validations.validate_file_cpyright(text):
@@ -1243,10 +1226,7 @@ class FileBuilder(object):
         Raise SPDXValueError if not free form text.
         Raise CardinalityError if more than one.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             if not self.file_notice_set:
                 self.file_notice_set = True
                 if validations.validate_file_notice(text):
@@ -1262,10 +1242,7 @@ class FileBuilder(object):
         """
         Raise OrderError if no package/unpackaged file is defined.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             self.file(doc).add_contrib(value)
         else:
             raise OrderError("File::Contributor")
@@ -1274,10 +1251,7 @@ class FileBuilder(object):
         """
         Raise OrderError if no package/unpackaged file is defined.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             self.file(doc).add_depend(value)
         else:
             raise OrderError("File::Dependency")
@@ -1287,10 +1261,7 @@ class FileBuilder(object):
         Set a file name, uri or home artificat.
         Raise OrderError if no package/unpackaged file is defined.
         """
-        if (
-            (self.has_package(doc) and self.has_file(doc))
-            or (self.has_unpackaged_file(doc) and not self.package_set)
-        ):
+        if (self._build_file_valid(doc)):
             self.file(doc).add_artifact(symbol, value)
         else:
             raise OrderError("File::Artificat")

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -1040,7 +1040,6 @@ class FileBuilder(object):
         else:
             # Starting with SPDX 2.0, file entries may proceed any package information section
             doc.unpackaged_files.append(file.File(name))
-            # raise OrderError("File::Name")  #TODO: CLEANUP
         # A file name marks the start of a new file instance.
         # The builder must be reset
         # FIXME: this state does not make sense

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -471,6 +471,9 @@ class Writer(
         self.document_object["SPDXID"] = self.spdx_id(self.document.spdx_id)
         self.document_object["name"] = self.document.name
 
+        if self.document.unpackaged_files:
+            self.document_object["files"] = self.document.unpackaged_files
+
         package_objects = []
         for package in self.document.packages:
             package_info_object = self.create_package_info(package)

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -182,7 +182,10 @@ class FileWriter(BaseWriter):
 
         return artifact_of_objects
 
-    def create_file_info(self, package):
+    def create_pkg_file_info(self, package):
+        return self.create_file_info(package.files)
+
+    def create_file_info(self, files):
         file_types = {
             1: "fileType_source",
             2: "fileType_binary",
@@ -190,7 +193,6 @@ class FileWriter(BaseWriter):
             4: "fileType_other",
         }
         file_objects = []
-        files = package.files
 
         for file in files:
             file_object = dict()
@@ -472,12 +474,12 @@ class Writer(
         self.document_object["name"] = self.document.name
 
         if self.document.unpackaged_files:
-            self.document_object["files"] = self.document.unpackaged_files
+            self.document_object["files"] = self.create_file_info(self.document.unpackaged_files)
 
         package_objects = []
         for package in self.document.packages:
             package_info_object = self.create_package_info(package)
-            package_info_object["files"] = self.create_file_info(package)
+            package_info_object["files"] = self.create_pkg_file_info(package)
             package_objects.append({"Package": package_info_object})
 
         self.document_object["documentDescribes"] = package_objects

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -358,6 +358,10 @@ def write_document(document, out, validate=True):
         write_relationship(relationship, out)
         write_separators(out)
 
+    # Write out unpackaged file info
+    for spdx_file in document.unpackaged_files:
+        write_file(spdx_file, out)
+
     # Write out package info
     for package in document.packages:
         write_package(package, out)

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -361,6 +361,7 @@ def write_document(document, out, validate=True):
     # Write out unpackaged file info
     for spdx_file in document.unpackaged_files:
         write_file(spdx_file, out)
+        write_separators(out)
 
     # Write out package info
     for package in document.packages:

--- a/tests/data/doc_parse/SBOMexpected.json
+++ b/tests/data/doc_parse/SBOMexpected.json
@@ -30,6 +30,7 @@
   ],
   "created": "2020-07-23T18:30:22Z",
   "creatorComment": null,
+  "files": [],
   "packages": [
     {
       "id": "SPDXRef-Package-xyz",

--- a/tests/data/doc_parse/expected.json
+++ b/tests/data/doc_parse/expected.json
@@ -34,6 +34,7 @@
   ],
   "created": "2010-02-03T00:00:00Z",
   "creatorComment": "This is an example of an SPDX spreadsheet format",
+  "files: [],
   "packages": [
     {
       "id": "SPDXRef-Package",

--- a/tests/data/doc_parse/expected.json
+++ b/tests/data/doc_parse/expected.json
@@ -34,7 +34,7 @@
   ],
   "created": "2010-02-03T00:00:00Z",
   "creatorComment": "This is an example of an SPDX spreadsheet format",
-  "files: [],
+  "files": [],
   "packages": [
     {
       "id": "SPDXRef-Package",

--- a/tests/data/doc_parse/spdx-expected-unpackaged-files.json
+++ b/tests/data/doc_parse/spdx-expected-unpackaged-files.json
@@ -38,7 +38,7 @@
     {
           "id": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File1",
           "name": "file.bin",
-          "type": 1,
+          "type": 4,
           "comment": null,
           "licenseConcluded": {
             "type": "Single",
@@ -129,38 +129,7 @@
         "identifier": "SHA1",
         "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
       },
-      "files": [
-        {
-          "id": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File1",
-          "name": "file.bin",
-          "type": 4,
-          "comment": null,
-          "licenseConcluded": {
-            "type": "Single",
-            "identifier": "Apache-2.0",
-            "name": "Apache License 2.0"
-          },
-          "copyrightText": "Copyright 2022 Example Client Inc.",
-          "licenseComment": null,
-          "notice": null,
-          "checksum": {
-            "identifier": "SHA1",
-            "value": "1b30f385d353620c845594d7ef96b3dd6d17a69a"
-          },
-          "licenseInfoFromFiles": [
-            {
-              "type": "Single",
-              "identifier": "Apache-2.0",
-              "name": "Apache License 2.0"
-            }
-          ],
-          "contributors": [],
-          "dependencies": [],
-          "artifactOfProjectName": [],
-          "artifactOfProjectHome": [],
-          "artifactOfProjectURI": []
-        }
-      ],
+      "files": [],
       "licenseInfoFromFiles": [
         {
           "type": "Single",

--- a/tests/data/doc_parse/spdx-expected-unpackaged-files.json
+++ b/tests/data/doc_parse/spdx-expected-unpackaged-files.json
@@ -92,7 +92,6 @@
         "identifier": [
           "Apache-1.0",
           "Apache-2.0",
-          "LicenseRef-1",
           "LicenseRef-2",
           "LicenseRef-3",
           "LicenseRef-4",
@@ -102,7 +101,6 @@
           "Apache License 1.0",
           "Apache License 2.0",
           "CyberNeko License",
-          "LicenseRef-1",
           "LicenseRef-2",
           "LicenseRef-4",
           "Mozilla Public License 1.1"
@@ -112,7 +110,6 @@
         "type": "Conjunction",
         "identifier": [
           "Apache-2.0",
-          "LicenseRef-1",
           "LicenseRef-2",
           "LicenseRef-3",
           "LicenseRef-4",
@@ -121,7 +118,6 @@
         "name": [
           "Apache License 2.0",
           "CyberNeko License",
-          "LicenseRef-1",
           "LicenseRef-2",
           "LicenseRef-4",
           "Mozilla Public License 1.1"
@@ -135,8 +131,8 @@
       },
       "files": [
         {
-          "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2",
-          "name": "src/org/spdx/parser/DOAPProject.java",
+          "id": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File1",
+          "name": "file.bin",
           "type": 1,
           "comment": null,
           "licenseConcluded": {
@@ -144,12 +140,12 @@
             "identifier": "Apache-2.0",
             "name": "Apache License 2.0"
           },
-          "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.",
+          "copyrightText": "Copyright 2022 Example Client Inc.",
           "licenseComment": null,
           "notice": null,
           "checksum": {
             "identifier": "SHA1",
-            "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+            "value": "1b30f385d353620c845594d7ef96b3dd6d17a69a"
           },
           "licenseInfoFromFiles": [
             {
@@ -175,11 +171,6 @@
           "type": "Single",
           "identifier": "Apache-2.0",
           "name": "Apache License 2.0"
-        },
-        {
-          "type": "Single",
-          "identifier": "LicenseRef-1",
-          "name": "LicenseRef-1"
         },
         {
           "type": "Single",
@@ -222,13 +213,6 @@
     }
   ],
   "extractedLicenses": [
-    {
-      "name": "LicenseRef-1",
-      "identifier": "LicenseRef-1",
-      "text": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */",
-      "comment": null,
-      "cross_refs": []
-    },
     {
       "name": "LicenseRef-2",
       "identifier": "LicenseRef-2",

--- a/tests/data/doc_parse/spdx-expected-unpackaged-files.json
+++ b/tests/data/doc_parse/spdx-expected-unpackaged-files.json
@@ -129,7 +129,38 @@
         "identifier": "SHA1",
         "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
       },
-      "files": [],
+      "files": [
+        {
+	  "id": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File2",
+	  "name": "etc/message.dat",
+	  "type": 4,
+	  "comment": null,
+	  "licenseConcluded": {
+	    "type": "Single",
+	    "identifier": "Apache-2.0",
+	    "name": "Apache License 2.0"
+	  },
+	  "copyrightText": "Copyright 2022 Example Client Inc.",
+	  "licenseComment": null,
+	  "notice": null,
+	  "checksum": {
+	    "identifier": "SHA1",
+	    "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+	  },
+	  "licenseInfoFromFiles": [
+	    {
+	      "type": "Single",
+	      "identifier": "Apache-2.0",
+	      "name": "Apache License 2.0"
+	    }
+	  ],
+	  "contributors": [],
+	  "dependencies": [],
+	  "artifactOfProjectName": [],
+	  "artifactOfProjectHome": [],
+	  "artifactOfProjectURI": []
+	}
+      ],
       "licenseInfoFromFiles": [
         {
           "type": "Single",

--- a/tests/data/doc_parse/spdx-expected-unpackaged-files.json
+++ b/tests/data/doc_parse/spdx-expected-unpackaged-files.json
@@ -133,7 +133,7 @@
         {
           "id": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File1",
           "name": "file.bin",
-          "type": 1,
+          "type": 4,
           "comment": null,
           "licenseConcluded": {
             "type": "Single",

--- a/tests/data/doc_parse/spdx-expected-unpackaged-files.json
+++ b/tests/data/doc_parse/spdx-expected-unpackaged-files.json
@@ -1,0 +1,312 @@
+{
+  "id": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-DOCUMENT",
+  "specVersion": {
+    "major": 2,
+    "minor": 1
+  },
+  "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206",
+  "name": "Sample_Document-V2.1",
+  "comment": "This is a sample spreadsheet",
+  "dataLicense": {
+    "type": "Single",
+    "identifier": "CC0-1.0",
+    "name": "Creative Commons Zero v1.0 Universal"
+  },
+  "licenseListVersion": {
+    "major": 3,
+    "minor": 6
+  },
+  "creators": [
+    {
+      "name": "A. Developer",
+      "email": null,
+      "type": "Person"
+    },
+    {
+      "name": "Sample Group Inc.",
+      "email": null,
+      "type": "Organization"
+    },
+    {
+      "name": "SomeExampleTool-V1.0",
+      "type": "Tool"
+    }
+  ],
+  "created": "2022-05-31T00:00:00Z",
+  "creatorComment": "This is an example of an SPDX spreadsheet format",
+  "files": [
+    {
+          "id": "https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File1",
+          "name": "file.bin",
+          "type": 1,
+          "comment": null,
+          "licenseConcluded": {
+            "type": "Single",
+            "identifier": "Apache-2.0",
+            "name": "Apache License 2.0"
+          },
+          "copyrightText": "Copyright 2022 Example Client Inc.",
+          "licenseComment": null,
+          "notice": null,
+          "checksum": {
+            "identifier": "SHA1",
+            "value": "1b30f385d353620c845594d7ef96b3dd6d17a69a"
+          },
+          "licenseInfoFromFiles": [
+            {
+              "type": "Single",
+              "identifier": "Apache-2.0",
+              "name": "Apache License 2.0"
+            }
+          ],
+          "contributors": [],
+          "dependencies": [],
+          "artifactOfProjectName": [],
+          "artifactOfProjectHome": [],
+          "artifactOfProjectURI": []
+    }
+  ],
+  "packages": [
+    {
+      "id": "SPDXRef-Package",
+      "name": "SPDX Translator",
+      "packageFileName": "spdxtranslator-1.0.zip",
+      "summary": "SPDX Translator utility",
+      "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.",
+      "versionInfo": "Version 0.9.2",
+      "sourceInfo": "Version 1.0 of the SPDX Translator application",
+      "downloadLocation": "http://www.spdx.org/tools",
+      "homepage": null,
+      "originator": {
+        "name": "SPDX",
+        "email": null,
+        "type": "Organization"
+      },
+      "supplier": {
+        "name": "Linux Foundation",
+        "email": null,
+        "type": "Organization"
+      },
+      "licenseConcluded": {
+        "type": "Conjunction",
+        "identifier": [
+          "Apache-1.0",
+          "Apache-2.0",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-3",
+          "LicenseRef-4",
+          "MPL-1.1"
+        ],
+        "name": [
+          "Apache License 1.0",
+          "Apache License 2.0",
+          "CyberNeko License",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-4",
+          "Mozilla Public License 1.1"
+        ]
+      },
+      "licenseDeclared": {
+        "type": "Conjunction",
+        "identifier": [
+          "Apache-2.0",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-3",
+          "LicenseRef-4",
+          "MPL-1.1"
+        ],
+        "name": [
+          "Apache License 2.0",
+          "CyberNeko License",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-4",
+          "Mozilla Public License 1.1"
+        ]
+      },
+      "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.",
+      "licenseComment": "The declared license information can be found in the NOTICE file at the root of the archive file",
+      "checksum": {
+        "identifier": "SHA1",
+        "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+      },
+      "files": [
+        {
+          "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2",
+          "name": "src/org/spdx/parser/DOAPProject.java",
+          "type": 1,
+          "comment": null,
+          "licenseConcluded": {
+            "type": "Single",
+            "identifier": "Apache-2.0",
+            "name": "Apache License 2.0"
+          },
+          "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.",
+          "licenseComment": null,
+          "notice": null,
+          "checksum": {
+            "identifier": "SHA1",
+            "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+          },
+          "licenseInfoFromFiles": [
+            {
+              "type": "Single",
+              "identifier": "Apache-2.0",
+              "name": "Apache License 2.0"
+            }
+          ],
+          "contributors": [],
+          "dependencies": [],
+          "artifactOfProjectName": [],
+          "artifactOfProjectHome": [],
+          "artifactOfProjectURI": []
+        }
+      ],
+      "licenseInfoFromFiles": [
+        {
+          "type": "Single",
+          "identifier": "Apache-1.0",
+          "name": "Apache License 1.0"
+        },
+        {
+          "type": "Single",
+          "identifier": "Apache-2.0",
+          "name": "Apache License 2.0"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-1",
+          "name": "LicenseRef-1"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-2",
+          "name": "LicenseRef-2"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-3",
+          "name": "CyberNeko License"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-4",
+          "name": "LicenseRef-4"
+        },
+        {
+          "type": "Single",
+          "identifier": "MPL-1.1",
+          "name": "Mozilla Public License 1.1"
+        }
+      ],
+      "verificationCode": {
+        "value": "4e3211c67a2d28fced849ee1bb76e7391b93feba",
+        "excludedFilesNames": [
+          "SpdxTranslatorSpdx.rdf",
+          "SpdxTranslatorSpdx.txt"
+        ]
+      }
+    }
+  ],
+  "externalDocumentRefs": [
+    {
+      "externalDocumentId": "DocumentRef-spdx-tool-2.1",
+      "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301",
+      "checksum": {
+        "identifier": "SHA1",
+        "value": "d6a770ba38583ed4bb4525bd96e50461655d2759"
+      }
+    }
+  ],
+  "extractedLicenses": [
+    {
+      "name": "LicenseRef-1",
+      "identifier": "LicenseRef-1",
+      "text": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */",
+      "comment": null,
+      "cross_refs": []
+    },
+    {
+      "name": "LicenseRef-2",
+      "identifier": "LicenseRef-2",
+      "text": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ",
+      "comment": null,
+      "cross_refs": []
+    },
+    {
+      "name": "CyberNeko License",
+      "identifier": "LicenseRef-3",
+      "text": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+      "comment": "This is tye CyperNeko License",
+      "cross_refs": [
+        "http://justasample.url.com",
+        "http://people.apache.org/~andyc/neko/LICENSE"
+      ]
+    },
+    {
+      "name": "LicenseRef-4",
+      "identifier": "LicenseRef-4",
+      "text": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ",
+      "comment": null,
+      "cross_refs": []
+    }
+  ],
+  "annotations": [
+    {
+      "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45",
+      "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses",
+      "type": "REVIEW",
+      "annotator": {
+        "name": "Jim Reviewer",
+        "email": null,
+        "type": "Person"
+      },
+      "date": "2012-06-13T00:00:00Z"
+    }
+  ],
+  "reviews": [
+    {
+      "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses",
+      "reviewer": {
+        "name": "Joe Reviewer",
+        "email": null,
+        "type": "Person"
+      },
+      "date": "2010-02-10T00:00:00Z"
+    },
+    {
+      "comment": "Another example reviewer.",
+      "reviewer": {
+        "name": "Suzanne Reviewer",
+        "email": null,
+        "type": "Person"
+      },
+      "date": "2011-03-13T00:00:00Z"
+    }
+  ],
+  "snippets": [
+    {
+      "id": "SPDXRef-Snippet",
+      "name": "from linux kernel",
+      "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.",
+      "copyrightText": "Copyright 2008-2010 John Smith",
+      "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
+      "fileId": "SPDXRef-DoapSource",
+      "licenseConcluded": {
+        "type": "Single",
+        "identifier": "Apache-2.0",
+        "name": "Apache License 2.0"
+      },
+      "licenseInfoFromSnippet": [
+        {
+          "type": "Single",
+          "identifier": "Apache-2.0",
+          "name": "Apache License 2.0"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/doc_parse/spdx-expected.json
+++ b/tests/data/doc_parse/spdx-expected.json
@@ -34,6 +34,7 @@
   ],
   "created": "2010-02-03T00:00:00Z",
   "creatorComment": "This is an example of an SPDX spreadsheet format",
+  "files": [],
   "packages": [
     {
       "id": "SPDXRef-Package",

--- a/tests/data/formats/SPDXRdfExample.rdf
+++ b/tests/data/formats/SPDXRdfExample.rdf
@@ -269,7 +269,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
         <name>SPDX Translator</name>
         <versionInfo>Version 0.9.2</versionInfo>
         <licenseInfoFromFiles rdf:nodeID="A1"/>
-        <hasFile rdf:nodeID="A2"/>
+        <hasFile rdf:resource="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2"/>
         <licenseInfoFromFiles rdf:nodeID="A3"/>
         <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
         <licenseDeclared>

--- a/tests/data/formats/SPDXRdfExample.rdf
+++ b/tests/data/formats/SPDXRdfExample.rdf
@@ -39,7 +39,7 @@
       </ExternalDocumentRef>
     </externalDocumentRef>
     <referencesFile>
-      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">
         <licenseConcluded>
           <ExtractedLicensingInfo rdf:nodeID="A1">
             <extractedText>/*
@@ -142,7 +142,7 @@
         <downloadLocation>http://www.spdx.org/tools</downloadLocation>
         <filesAnalyzed>true</filesAnalyzed>
         <supplier>Organization:Linux Foundation</supplier>
-        <hasFile rdf:nodeID="A0"/>
+        <hasFile rdf:resource="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1"/>
         <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
         <packageVerificationCode>
           <PackageVerificationCode>

--- a/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
+++ b/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
@@ -83,13 +83,28 @@
         <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
       </Relationship>
     </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File2">
+        <copyrightText>Copyright 2022 Example Client Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_other"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>etc/message.dat</fileName>
+      </File>
+    </referencesFile>
     <describesPackage>
       <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
         <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
         <downloadLocation>http://www.spdx.org/tools</downloadLocation>
         <filesAnalyzed>true</filesAnalyzed>
         <supplier>Organization:Linux Foundation</supplier>
-        <hasFile rdf:nodeID="A0"/>
+        <hasFile rdf:resource="https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File2"/>
         <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
         <packageVerificationCode>
           <PackageVerificationCode>
@@ -214,7 +229,6 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
         <licenseInfoFromFiles rdf:nodeID="A4"/>
         <name>SPDX Translator</name>
         <versionInfo>Version 0.9.2</versionInfo>
-        <hasFile rdf:nodeID="A2"/>
         <licenseInfoFromFiles rdf:nodeID="A3"/>
         <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
         <licenseDeclared>

--- a/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
+++ b/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
@@ -214,7 +214,6 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
         <licenseInfoFromFiles rdf:nodeID="A4"/>
         <name>SPDX Translator</name>
         <versionInfo>Version 0.9.2</versionInfo>
-        <licenseInfoFromFiles/>
         <hasFile rdf:nodeID="A2"/>
         <licenseInfoFromFiles rdf:nodeID="A3"/>
         <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>

--- a/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
+++ b/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
@@ -43,7 +43,7 @@
         <copyrightText>Copyright 2022 Example Client Inc.</copyrightText>
         <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
         <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
-        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_other"/>
         <checksum>
           <Checksum>
             <checksumValue>1b30f385d353620c845594d7ef96b3dd6d17a69a</checksumValue>

--- a/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
+++ b/tests/data/formats/SPDXRdfUnpackagedFileExample.rdf
@@ -1,0 +1,250 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2022-05-31T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SomeExampleTool-V1.0</creator>
+        <creator>Organization: Sample Group Inc.</creator>
+        <creator>Person: A. Developer</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-F16320D4-36AB-476D-9691-59E1BAD31206#SPDXRef-File1">
+        <copyrightText>Copyright 2022 Example Client Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>1b30f385d353620c845594d7ef96b3dd6d17a69a</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>file.bin</fileName>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/test_rdf_parser.py
+++ b/tests/test_rdf_parser.py
@@ -45,3 +45,12 @@ class TestParser(unittest.TestCase):
             expected = json.load(ex)
 
         assert result == expected
+
+    def test_rdf_parser_unpacked_files(self, regen=False):
+        parser = rdf.Parser(RDFBuilder(), StandardLogger())
+        test_file = utils_test.get_test_loc('formats/SPDXRdfUnpackagedFileExample.rdf', test_data_dir=utils_test.test_data_dir)
+        with io.open(test_file, 'rb') as f:
+            document, _ = parser.parse(f)
+        expected_loc = utils_test.get_test_loc('doc_parse/spdx-expected-unpackaged-files.json', test_data_dir=utils_test.test_data_dir)
+        self.check_document(document, expected_loc, regen=regen)
+

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -207,6 +207,17 @@ class TestParser(TestCase):
         'ReviewComment: <text>Alice was also here.</text>'
     ])
 
+    unpackaged_file_str = '\n'.join([
+        'FileName: testfile.text-info',
+        'SPDXID: SPDXRef-File',
+        'FileType: OTHER',
+        'FileChecksum: SHA1: c940141b1f4d098f12812675e9cfa5fe72e07bab',
+        'LicenseConcluded: Apache-2.0',
+        'LicenseInfoInFile: Apache-2.0',
+        'FileCopyrightText: <text>Copyright 2022 Acme Inc.</text>',
+        'FileComment: <text>Very long file</text>'
+        ])
+
     package_str = '\n'.join([
         'PackageName: Test',
         'SPDXID: SPDXRef-Package',
@@ -259,7 +270,7 @@ class TestParser(TestCase):
         'LicenseInfoInSnippet: Apache-2.0',
     ])
 
-    complete_str = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}'.format(document_str, creation_str, review_str, package_str, file_str, snippet_str)
+    complete_str = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}\n{6}'.format(document_str, creation_str, review_str, unpackaged_file_str, package_str, file_str, snippet_str)
 
     def setUp(self):
         self.p = Parser(Builder(), StandardLogger())
@@ -318,6 +329,16 @@ class TestParser(TestCase):
         assert len(spdx_file.artifact_of_project_name) == 1
         assert len(spdx_file.artifact_of_project_home) == 1
         assert len(spdx_file.artifact_of_project_uri) == 1
+
+    def test_unpackaged_file(self):
+        document, error = self.p.parse(self.complete_str)
+        assert document is not None
+        assert not error
+        assert len(document.files) == 1
+        spdx_file = document.unpackaged_files[0]
+        assert spdx_file.name == 'testfile.text-info'
+        assert spdx_file.spdx_id == 'SPDXRef-File'
+        assert spdx_file.type == spdx.file.FileType.OTHER
 
     def test_unknown_tag(self):
 

--- a/tests/test_write_anything.py
+++ b/tests/test_write_anything.py
@@ -35,7 +35,12 @@ UNSTABLE_CONVERSIONS = {
     "SPDXRdfExample.rdf-yaml",
     "SPDXRdfExample.rdf-xml",
     "SPDXRdfExample.rdf-json",
-    "SPDXRdfExample.rdf-tag"
+    "SPDXRdfExample.rdf-tag",
+    "SPDXRdfUnpackagedFileExample.rdf-rdf",
+    "SPDXRdfUnpackagedFileExample.rdf-yaml",
+    "SPDXRdfUnpackagedFileExample.rdf-xml",
+    "SPDXRdfUnpackagedFileExample.rdf-json",
+    "SPDXRdfUnpackagedFileExample.rdf-tag"
 }
 
 @pytest.mark.parametrize("out_format", ['rdf', 'yaml', 'xml', 'json', 'tag'])

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -510,6 +510,7 @@ class TestParserUtils(object):
             ('creators', [cls.entity_to_dict(creator) for creator in creators]),
             ('created', utils.datetime_iso_format(doc.creation_info.created)),
             ('creatorComment', doc.creation_info.comment),
+            ('files', cls.files_to_list(doc.unpackaged_files)),
             ('packages', [cls.package_to_dict(p) for p in doc.packages]),
             ('externalDocumentRefs', cls.ext_document_references_to_list(sorted(doc.ext_document_references))),
             ('extractedLicenses', cls.extracted_licenses_to_list(sorted(doc.extracted_licenses))),


### PR DESCRIPTION
Add Files without associated packages, as allowed by the spec but not currently supported in Document class.

- [x] unpackaged Files data model
- [x] tag/value Writer, Parser & tests
- [x] RDF Writer, Parser & tests
- [x] JSON-yaml-XML Writer, Parser & tests

Also leverages the unpackaged Files data model, to fix rdf parser bug where every `referencesFile` are incorrectly added to the last-listed Package.

Resolves [spdx/tools-python #181](https://github.com/spdx/tools-python/issues/181)

Signed-off-by: Brandon J. Van Vaerenbergh brandon@finitestate.io